### PR TITLE
Make imprint and colophon use se.css

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -4,6 +4,7 @@
 		<title>Colophon</title>
 		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/se.css" rel="stylesheet" type="text/css"/>
 	</head>
 	<body epub:type="backmatter">
 		<section id="colophon" epub:type="colophon">

--- a/src/epub/text/imprint.xhtml
+++ b/src/epub/text/imprint.xhtml
@@ -4,6 +4,7 @@
 		<title>Imprint</title>
 		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/se.css" rel="stylesheet" type="text/css"/>
 	</head>
 	<body epub:type="frontmatter">
 		<section id="imprint" epub:type="imprint">


### PR DESCRIPTION
If I get some spare time I might try writing a lint rule to catch this. I feel like I've seen this problem in other productions before.